### PR TITLE
feat: implement unified base parser architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,7 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tarzi"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tarzi"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 authors = ["xmingc <chenxm35@gmail.com>"]
 description = "Rust-native lite search for AI applications"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@
 pip install tarzi
 ```
 
+## CLI Commands
+
+Tarzi provides two command-line interfaces:
+
+- **`tarzi`**: Native Rust CLI (faster, more efficient)
+- **`pytarzi`**: Python CLI (easier to extend, same functionality)
+
+Both CLIs support the same commands and configuration precedence.
+
 ## Usage Examples
 
 * Examples in Python and Rust: [examples](/examples/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(project_root))
 project = "tarzi"
 copyright = "2025, Mirasurf"
 author = "xmingc"
-release = "0.0.11"
+release = "latest"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,12 +9,16 @@ tarzi can be configured through configuration files, environment variables, and 
 Configuration File
 ------------------
 
-tarzi reads configuration from the following sources in order:
+tarzi reads configuration from the following sources in order of precedence (highest to lowest):
 
-1. `.tarzi.toml` under user home directory
-2. `tarzi.toml` in current project root
+1. **CLI parameters** (highest priority)
+2. **~/.tarzi.toml** (user home directory)
+3. **tarzi.toml** (current project root)
+4. **Default values** (lowest priority)
 
 You can refer to `tarzi.toml <https://github.com/mirasurf/tarzi.rs/blob/main/tarzi.toml>`_ for the default values.
+
+**Note**: The Python CLI is available as `pytarzi` command, while the Rust CLI remains as `tarzi` command.
 
 Environment Variables
 ---------------------
@@ -79,13 +83,14 @@ Configuration Precedence
 
 Configuration values are applied in the following order (highest to lowest priority):
 
-1. Programmatic configuration
-2. Environment variables (limited support - see above)
-3. Configuration file
-4. Default values
+1. **CLI parameters** (command line arguments)
+2. **Environment variables** (limited support - see above)
+3. **~/.tarzi.toml** (user configuration file)
+4. **tarzi.toml** (project configuration file)
+5. **Default values** (hardcoded defaults)
 
 **Note**: Environment variables currently only override proxy settings and API keys. 
-All other configuration must be set via TOML file or programmatically.
+All other configuration must be set via TOML file, CLI parameters, or programmatically.
 
 API Search Configuration
 ------------------------
@@ -98,6 +103,20 @@ tarzi supports multiple API search providers with automatic fallback capabilitie
 - **Exa Search API**: AI-powered semantic search with enhanced relevance
 - **Travily API**: Specialized travel and location-based search
 - **DuckDuckGo API**: Privacy-focused search (limited functionality, no API key required)
+- **Baidu API**: Chinese search engine with API support
+
+**Engine Capabilities:**
+
+| Engine        | Web Query | API Query | API Key Required |
+|---------------|-----------|-----------|------------------|
+| Bing          | Yes       | No        | N/A              |
+| Google        | Yes       | Yes       | Yes              |
+| Brave         | Yes       | Yes       | Yes              |
+| DuckDuckGo    | Yes       | Yes       | No               |
+| Exa           | Yes       | Yes       | Yes              |
+| Google Serper | Yes       | Yes       | Yes              |
+| Travily       | No        | Yes       | Yes              |
+| Baidu         | Yes       | Yes       | Yes              |
 
 **Autoswitch Strategies:**
 - **smart**: Automatically fallback to available providers if primary fails
@@ -118,3 +137,4 @@ tarzi supports multiple API search providers with automatic fallback capabilitie
    google_serper_api_key = "your-google-serper-api-key"
    exa_api_key = "your-exa-api-key"
    travily_api_key = "your-travily-api-key"
+   baidu_api_key = "your-baidu-api-key"

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -3,6 +3,26 @@ Development Guide
 
 This guide covers development setup, building from source, and contributing to tarzi.
 
+Architecture Overview
+====================
+
+Parser System
+~~~~~~~~~~~~
+
+Tarzi uses a unified parser architecture for search engines:
+
+- **Base Traits**: `BaseSearchParser`, `WebSearchParser`, `ApiSearchParser`
+- **Base Structs**: `BaseWebParser`, `BaseApiParser` for common functionality
+- **Parser Factory**: Mode-aware parser selection and management
+- **Unified Parser**: Combines web and API parsing capabilities
+
+To add a new search engine:
+
+1. Create a new parser file (e.g., `src/search/parser/newengine.rs`)
+2. Implement the appropriate base traits
+3. Add the parser to `ParserFactory::get_parser()`
+4. Update `SearchEngineType` enum if needed
+
 Development Setup
 -----------------
 
@@ -236,4 +256,4 @@ Release Process
 4. **Create release**
    - Tag the release
    - Upload to crates.io and PyPI
-   - Update documentation 
+   - Update documentation

--- a/docs/examples/api_search.rst
+++ b/docs/examples/api_search.rst
@@ -3,6 +3,19 @@ API Search Examples
 
 This guide demonstrates how to use tarzi's API search features with multiple providers and automatic fallback capabilities.
 
+Parser Architecture
+-------------------
+
+Tarzi uses a unified parser architecture where all search engines inherit from base parser traits:
+
+- **BaseSearchParser**: Core trait with name, engine type, and support checking
+- **WebSearchParser**: HTML-based parsing for browser scraping
+- **ApiSearchParser**: JSON-based parsing for API responses
+- **UnifiedParser**: Combines web and API parsing capabilities
+- **ParserFactory**: Mode-aware parser selection (WebQuery vs ApiQuery)
+
+This architecture ensures consistent parsing across all search engines and makes it easy to add new engines.
+
 Basic API Search
 ---------------
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -56,12 +56,20 @@ Key features:
 Search Module
 ~~~~~~~~~~~~~
 
-The Search module provides comprehensive search engine integration:
+The Search module provides comprehensive search engine integration with a unified parser architecture:
+
+**Base Parser Architecture**
+   All search engines inherit from base parser traits:
+   
+   - **BaseSearchParser**: Core trait with name, engine type, and support checking
+   - **WebSearchParser**: HTML-based parsing with `parse_html()` method
+   - **ApiSearchParser**: JSON-based parsing with `parse_json()` method
+   - **UnifiedParser**: Combines web and API parsing capabilities
 
 **Browser-Based Search**
    Scrape search results directly from search engine pages:
    
-   - Google, Bing, DuckDuckGo, Brave Search support
+   - Google, Bing, DuckDuckGo, Brave Search, Baidu support
    - Custom search engine configuration
    - Anti-detection measures
 
@@ -73,6 +81,13 @@ The Search module provides comprehensive search engine integration:
    - **Proxy Support**: Full proxy support for all API providers
    - **Structured Results**: Consistent result format across all providers
 
+**Parser Factory**
+   Factory pattern for creating and managing parsers:
+   
+   - Mode-aware parser selection (WebQuery vs ApiQuery)
+   - Custom parser registration
+   - Automatic fallback for unsupported combinations
+
 Key features:
 
 - Multiple search engine support
@@ -80,6 +95,7 @@ Key features:
 - Search result ranking
 - Snippet extraction
 - URL validation and cleaning
+- Extensible parser architecture
 
 Getting Started
 ---------------

--- a/docs/rust_api/index.rst
+++ b/docs/rust_api/index.rst
@@ -10,16 +10,25 @@ Quick Reference
    - ``tarzi::converter`` - HTML conversion functionality
    - ``tarzi::fetcher`` - Web page fetching
    - ``tarzi::search`` - Search engine integration
+   - ``tarzi::search::parser`` - Search result parsing
 
 **Main Structs**
    - ``Converter`` - HTML conversion
    - ``WebFetcher`` - Web page fetching
    - ``SearchEngine`` - Web search operations
+   - ``ParserFactory`` - Parser creation and management
+
+**Base Parser Traits**
+   - ``BaseSearchParser`` - Core parser trait
+   - ``WebSearchParser`` - HTML-based parsing
+   - ``ApiSearchParser`` - JSON-based parsing
+   - ``UnifiedParser`` - Combined web and API parsing
 
 **Enums**
    - ``Format`` - Output formats (Markdown, JSON, YAML, HTML)
    - ``FetchMode`` - Fetching strategies
    - ``SearchMode`` - Search strategies
+   - ``SearchEngineType`` - Supported search engines
 
 Basic Usage
 -----------
@@ -27,6 +36,7 @@ Basic Usage
 .. code-block:: rust
 
    use tarzi::{Converter, WebFetcher, SearchEngine, Format, FetchMode, SearchMode};
+   use tarzi::search::parser::{ParserFactory, SearchEngineType};
 
    #[tokio::main]
    async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -41,6 +51,11 @@ Basic Usage
        // Search web
        let mut search_engine = SearchEngine::new();
        let results = search_engine.search("agentic AI", SearchMode::WebQuery, 10).await?;
+
+       // Use parser factory
+       let factory = ParserFactory::new();
+       let parser = factory.get_parser(&SearchEngineType::Google, SearchMode::WebQuery);
+       let parsed_results = parser.parse(html_content, 10)?;
 
        Ok(())
    } 

--- a/examples/browser_driver_usage.rs
+++ b/examples/browser_driver_usage.rs
@@ -12,9 +12,9 @@ async fn main() -> Result<()> {
 
     println!("=== Browser Driver Integration Demo ===\n");
 
-    // Load configuration
-    let config = Config::load().unwrap_or_else(|_| {
-        println!("Using default configuration (tarzi.toml not found)");
+    // Load configuration with proper precedence
+    let config = Config::load_with_precedence().unwrap_or_else(|_| {
+        println!("Using default configuration (no config files found)");
         Config::default()
     });
 

--- a/examples/search_engines.rs
+++ b/examples/search_engines.rs
@@ -8,8 +8,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging
     tracing_subscriber::fmt::init();
 
-    // Load configuration
-    let config = Config::load_dev()?;
+    // Load configuration with proper precedence
+    let config = Config::load_with_precedence()?;
     println!("Loaded config with search engine: {}", config.search.engine);
     println!("Query pattern: {}", config.search.query_pattern);
 

--- a/examples/search_parser_usage.rs
+++ b/examples/search_parser_usage.rs
@@ -1,3 +1,4 @@
+use tarzi::SearchMode;
 use tarzi::search::parser::CustomParser;
 use tarzi::search::{
     CustomParserConfig, ParserFactory, SearchEngine, SearchEngineType, SearchResultParser,
@@ -70,7 +71,7 @@ async fn main() -> tarzi::Result<()> {
 
     for (engine_type, engine_name) in engines {
         println!("  Testing {engine_name} parser:");
-        let parser = factory.get_parser(&engine_type);
+        let parser = factory.get_parser(&engine_type, SearchMode::WebQuery);
         let mock_html = format!("<html><body>Mock HTML for {engine_name}</body></html>");
         let results = parser.parse(&mock_html, 3)?;
 
@@ -128,7 +129,7 @@ async fn main() -> tarzi::Result<()> {
     // Test the registered custom parsers
     for engine_name in ["CustomEngine1", "CustomEngine2", "SpecialSearchEngine"] {
         let engine_type = SearchEngineType::Custom(engine_name.to_string());
-        let parser = factory.get_parser(&engine_type);
+        let parser = factory.get_parser(&engine_type, SearchMode::WebQuery);
         let results = parser.parse("<html><body>Test</body></html>", 2)?;
 
         println!("  Results from {engine_name}:");
@@ -148,7 +149,7 @@ async fn main() -> tarzi::Result<()> {
     ];
 
     for engine_type in test_engines {
-        let parser = factory.get_parser(&engine_type);
+        let parser = factory.get_parser(&engine_type, SearchMode::WebQuery);
         println!(
             "  Parser: {} supports {:?}: {}",
             parser.name(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,17 @@
-[build-system]
-requires = ["maturin>=1.0,<2.0"]
-build-backend = "maturin"
-
 [project]
 name = "tarzi"
+version = "0.0.13"
 requires-python = ">=3.10"
+keywords = ["web-scraping", "search-engine", "ai-tools", "rust", "browser-automation"]
+description = "Rust-native lite search for AI applications"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "xmingc", email = "chenxm35@gmail.com"},
+]
+maintainers = [
+    {name = "xmingc", email = "chenxm35@gmail.com"},
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -18,17 +25,6 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
-]
-keywords = ["web-scraping", "search-engine", "ai-tools", "rust", "browser-automation"]
-version = "0.0.12"
-description = "Rust-native lite search for AI applications"
-readme = "README.md"
-license = {text = "Apache-2.0"}
-authors = [
-    {name = "xmingc", email = "chenxm35@gmail.com"},
-]
-maintainers = [
-    {name = "xmingc", email = "chenxm35@gmail.com"},
 ]
 
 [project.urls]
@@ -64,6 +60,10 @@ docs = [
     "sphinx-autoapi>=3.0.0",
 ]
 
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
 [tool.maturin]
 features = ["pyo3/extension-module"]
 module-name = "tarzi"
@@ -72,7 +72,7 @@ bindings = "pyo3"
 python-source = "python"
 
 [project.scripts]
-tarzi = "tarzi.__main__:main"
+pytarzi = "tarzi.__main__:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -113,7 +113,7 @@ pub const DEFAULT_FETCHER_MODE: &str = "browser_headless";
 pub const DEFAULT_FORMAT: &str = "markdown";
 
 /// Default search engine
-pub const DEFAULT_SEARCH_ENGINE: &str = "bing";
+pub const DEFAULT_SEARCH_ENGINE: &str = "duckduckgo";
 
 /// Default search mode
 pub const DEFAULT_SEARCH_MODE: &str = "webquery";

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use std::str::FromStr;
 use tarzi::{
     Result,
+    config::{CliConfigParams, Config},
     converter::{Converter, Format, convert_search_results},
     fetcher::{FetchMode, WebFetcher},
     search::{SearchEngine, SearchMode},
@@ -39,9 +40,6 @@ enum Commands {
         /// URL to fetch
         #[arg(short, long)]
         url: String,
-        /// Fetch mode: plain_request, browser_head, or browser_headless
-        #[arg(short, long, default_value = "plain_request")]
-        mode: String,
         /// Output format: html, markdown, json, or yaml
         #[arg(short, long, default_value = "html")]
         format: String,
@@ -57,9 +55,6 @@ enum Commands {
         /// Search query
         #[arg(short, long)]
         query: String,
-        /// Search mode: webquery or apiquery
-        #[arg(short, long, default_value = "webquery")]
-        mode: String,
         /// Number of results to return
         #[arg(short, long, default_value = "10")]
         limit: usize,
@@ -78,12 +73,6 @@ enum Commands {
         /// Search query
         #[arg(short, long)]
         query: String,
-        /// Search mode: webquery or apiquery
-        #[arg(short, long, default_value = "webquery")]
-        search_mode: String,
-        /// Fetch mode: plain_request, browser_head, or browser_headless
-        #[arg(short, long, default_value = "plain_request")]
-        fetch_mode: String,
         /// Number of results to return
         #[arg(short, long, default_value = "5")]
         limit: usize,
@@ -102,6 +91,9 @@ enum Commands {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Load configuration with proper precedence
+    let mut config = Config::load_with_precedence()?;
 
     match cli.command {
         Commands::Convert {
@@ -131,7 +123,6 @@ async fn main() -> Result<()> {
         }
         Commands::Fetch {
             url,
-            mode,
             format,
             output,
             verbose,
@@ -141,14 +132,18 @@ async fn main() -> Result<()> {
             tracing_subscriber::fmt().with_max_level(log_level).init();
 
             info!("Tarzi Fetch starting with verbose mode: {}", verbose);
-            info!("Fetching URL: {} with mode: {}", url, mode);
+            info!("Fetching URL: {} with mode: {}", url, format);
             debug!("Using format: {}", format);
 
-            let mut fetcher = WebFetcher::new();
-            let fetch_mode = FetchMode::from_str(&mode)?;
+            // Apply CLI parameters to config
+            let mut cli_params = CliConfigParams::new();
+            cli_params.fetcher_format = Some(format.clone());
+            config.apply_cli_params(&cli_params);
+
+            let mut fetcher = WebFetcher::from_config(&config);
             let format = Format::from_str(&format)?;
 
-            let result = fetcher.fetch(&url, fetch_mode, format).await?;
+            let result = fetcher.fetch(&url, FetchMode::PlainRequest, format).await?;
 
             info!(
                 "Successfully fetched and converted content ({} characters)",
@@ -164,7 +159,6 @@ async fn main() -> Result<()> {
         }
         Commands::Search {
             query,
-            mode,
             limit,
             format,
             output,
@@ -177,12 +171,16 @@ async fn main() -> Result<()> {
             info!("Tarzi Search starting with verbose mode: {}", verbose);
             info!("Starting search operation");
             info!("Query: '{}'", query);
-            info!("Mode: {}", mode);
             info!("Limit: {}", limit);
             info!("Format: {}", format);
 
-            let mut search_engine = SearchEngine::new();
-            let mode = SearchMode::from_str(&mode)?;
+            // Apply CLI parameters to config
+            let mut cli_params = CliConfigParams::new();
+            cli_params.search_limit = Some(limit);
+            config.apply_cli_params(&cli_params);
+
+            let mut search_engine = SearchEngine::from_config(&config);
+            let mode = SearchMode::from_str(&config.search.mode)?;
 
             info!("Search engine initialized, starting search...");
             let results = search_engine.search(&query, mode, limit).await?;
@@ -202,8 +200,6 @@ async fn main() -> Result<()> {
         }
         Commands::SearchAndFetch {
             query,
-            search_mode,
-            fetch_mode,
             limit,
             format,
             output,
@@ -219,19 +215,22 @@ async fn main() -> Result<()> {
             );
             info!("Starting search and fetch operation");
             info!("Query: '{}'", query);
-            info!("Search mode: {}", search_mode);
-            info!("Fetch mode: {}", fetch_mode);
             info!("Limit: {}", limit);
             info!("Format: {}", format);
 
-            let mut search_engine = SearchEngine::new();
-            let search_mode = SearchMode::from_str(&search_mode)?;
-            let fetch_mode = FetchMode::from_str(&fetch_mode)?;
+            // Apply CLI parameters to config
+            let mut cli_params = CliConfigParams::new();
+            cli_params.search_limit = Some(limit);
+            cli_params.fetcher_format = Some(format.clone());
+            config.apply_cli_params(&cli_params);
+
+            let mut search_engine = SearchEngine::from_config(&config);
+            let mode = SearchMode::from_str(&config.search.mode)?;
             let format = Format::from_str(&format)?;
 
             info!("Search engine initialized, starting search and fetch...");
             let results_with_content = search_engine
-                .search_and_fetch(&query, search_mode, limit, fetch_mode, format)
+                .search_and_fetch(&query, mode, limit, FetchMode::PlainRequest, format)
                 .await?;
 
             info!(

--- a/src/search/api.rs
+++ b/src/search/api.rs
@@ -61,6 +61,11 @@ impl ApiSearchManager {
         self.providers.insert(engine_type, provider);
     }
 
+    /// Check if a provider is registered for the given engine type
+    pub fn has_provider(&self, engine_type: &SearchEngineType) -> bool {
+        self.providers.contains_key(engine_type)
+    }
+
     pub async fn search(
         &self,
         engine_type: &SearchEngineType,

--- a/src/search/parser/baidu.rs
+++ b/src/search/parser/baidu.rs
@@ -1,113 +1,146 @@
+use super::super::types::{SearchEngineType, SearchResult};
 use super::SearchResultParser;
+use super::base::{
+    ApiSearchParser, BaseApiParser, BaseSearchParser, BaseWebParser, WebSearchParser,
+};
 use crate::Result;
-use crate::search::types::{SearchEngineType, SearchResult};
 use select::document::Document;
-use select::predicate::{Class, Name, Predicate};
-use tracing::{info, warn};
+use select::predicate::{And, Class, Descendant, Name};
+use serde_json::Value;
 
-pub struct BaiduParser;
+pub struct BaiduParser {
+    base: BaseWebParser,
+}
 
 impl BaiduParser {
     pub fn new() -> Self {
-        Self
+        Self {
+            base: BaseWebParser::new("BaiduParser".to_string(), SearchEngineType::Baidu),
+        }
     }
 }
 
-impl SearchResultParser for BaiduParser {
-    fn parse(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        info!("Parsing Baidu search results from HTML");
+impl BaseSearchParser for BaiduParser {
+    fn name(&self) -> &str {
+        self.base.name()
+    }
+    fn engine_type(&self) -> SearchEngineType {
+        self.base.engine_type()
+    }
+}
 
-        if html.is_empty() {
-            warn!("Empty HTML provided to BaiduParser");
-            return Ok(Vec::new());
-        }
-
+impl WebSearchParser for BaiduParser {
+    fn parse_html(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
         let document = Document::from(html);
         let mut results = Vec::new();
-
-        // Look for Baidu search result containers
-        // Baidu uses .result.c-container for individual result containers
-        let result_selector = Class("result").and(Class("c-container"));
-
-        for node in document.find(result_selector).take(limit * 2) {
-            // Skip if we already have enough results
-            if results.len() >= limit {
-                break;
-            }
-
-            // Skip ad entries (contains "data-tuiguang" or certain ad class markers)
-            let is_ad = node.attrs().any(|(k, _)| k.contains("data-tuiguang"))
-                || node
-                    .attr("class")
-                    .map(|c| c.contains("ec_ad") || c.contains("ad-block"))
-                    .unwrap_or(false);
-
-            if is_ad {
+        let result_selector = And(Class("result"), Class("c-container"));
+        for node in document.find(result_selector) {
+            // Skip ads
+            if node.attr("data-tuiguang").is_some() {
                 continue;
             }
-
-            // Extract title and URL from h3 a element
-            let title_link = node.find(Name("h3").descendant(Name("a"))).next();
-
-            let title = title_link
+            let title = node
+                .find(Descendant(Name("h3"), Name("a")))
+                .next()
                 .map(|n| n.text().trim().to_string())
                 .unwrap_or_default();
-
-            let url = title_link
+            let url = node
+                .find(Descendant(Name("h3"), Name("a")))
+                .next()
                 .and_then(|n| n.attr("href"))
-                .map(|href| {
-                    // Baidu sometimes uses redirect URLs or relative paths
-                    if href.starts_with("http") {
-                        href.to_string()
-                    } else if href.starts_with("/") {
-                        format!("https://www.baidu.com{href}")
-                    } else {
-                        href.to_string()
-                    }
-                })
-                .unwrap_or_default();
-
-            // Extract snippet from .c-abstract element
+                .unwrap_or_default()
+                .to_string();
             let snippet = node
                 .find(Class("c-abstract"))
                 .next()
                 .map(|n| n.text().trim().to_string())
                 .unwrap_or_default();
-
-            // Only add if we have at least a title
             if !title.is_empty() {
-                let result = SearchResult {
+                results.push(SearchResult {
                     title,
                     url,
                     snippet,
                     rank: results.len() + 1,
-                };
-                info!(
-                    "Extracted Baidu result #{}: {}",
-                    results.len() + 1,
-                    result.title
-                );
-                results.push(result);
+                });
+            }
+            if results.len() >= limit {
+                break;
             }
         }
-
-        info!(
-            "Successfully parsed {} Baidu search results from HTML",
-            results.len()
-        );
         Ok(results)
     }
+}
 
-    fn name(&self) -> &str {
-        "BaiduParser"
+impl SearchResultParser for BaiduParser {
+    fn parse(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        self.parse_html(html, limit)
     }
-
+    fn name(&self) -> &str {
+        BaseSearchParser::name(self)
+    }
     fn supports(&self, engine_type: &SearchEngineType) -> bool {
-        matches!(engine_type, SearchEngineType::Baidu)
+        BaseSearchParser::supports(self, engine_type)
     }
 }
 
 impl Default for BaiduParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct BaiduApiParser {
+    base: BaseApiParser,
+}
+
+impl BaiduApiParser {
+    pub fn new() -> Self {
+        Self {
+            base: BaseApiParser::new("BaiduApiParser".to_string(), SearchEngineType::Baidu),
+        }
+    }
+}
+
+impl BaseSearchParser for BaiduApiParser {
+    fn name(&self) -> &str {
+        self.base.name()
+    }
+    fn engine_type(&self) -> SearchEngineType {
+        self.base.engine_type()
+    }
+}
+
+impl ApiSearchParser for BaiduApiParser {
+    fn parse_json(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        let json: Value = serde_json::from_str(json_content)?;
+        let mut results = Vec::new();
+        if let Some(results_array) = json["results"].as_array() {
+            for (i, result) in results_array.iter().take(limit).enumerate() {
+                results.push(SearchResult {
+                    title: result["title"].as_str().unwrap_or("").to_string(),
+                    url: result["url"].as_str().unwrap_or("").to_string(),
+                    snippet: result["snippet"].as_str().unwrap_or("").to_string(),
+                    rank: i,
+                });
+            }
+        }
+        Ok(results)
+    }
+}
+
+impl SearchResultParser for BaiduApiParser {
+    fn parse(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        self.parse_json(json_content, limit)
+    }
+    fn name(&self) -> &str {
+        BaseSearchParser::name(self)
+    }
+    fn supports(&self, engine_type: &SearchEngineType) -> bool {
+        BaseSearchParser::supports(self, engine_type)
+    }
+}
+
+impl Default for BaiduApiParser {
     fn default() -> Self {
         Self::new()
     }

--- a/src/search/parser/base.rs
+++ b/src/search/parser/base.rs
@@ -1,0 +1,150 @@
+use super::super::types::{SearchEngineType, SearchResult};
+use crate::Result;
+use serde_json::Value;
+
+/// Base trait for all search result parsers
+pub trait BaseSearchParser: Send + Sync {
+    /// Get the name of the parser
+    fn name(&self) -> &str;
+
+    /// Get the engine type this parser supports
+    fn engine_type(&self) -> SearchEngineType;
+
+    /// Check if this parser can handle the given search engine type
+    fn supports(&self, engine_type: &SearchEngineType) -> bool {
+        &self.engine_type() == engine_type
+    }
+}
+
+/// Base trait for web query parsers (HTML-based)
+pub trait WebSearchParser: BaseSearchParser {
+    /// Parse search results from HTML content
+    fn parse_html(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>>;
+}
+
+/// Base trait for API query parsers (JSON-based)
+pub trait ApiSearchParser: BaseSearchParser {
+    /// Parse search results from JSON content
+    fn parse_json(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>>;
+}
+
+/// Unified parser trait that combines web and API parsing capabilities
+pub trait SearchResultParser: Send + Sync {
+    /// Parse search results from content (HTML or JSON)
+    fn parse(&self, content: &str, limit: usize) -> Result<Vec<SearchResult>>;
+
+    /// Get the name of the parser
+    fn name(&self) -> &str;
+
+    /// Check if this parser can handle the given search engine type
+    fn supports(&self, engine_type: &SearchEngineType) -> bool;
+}
+
+/// Base implementation for web parsers
+pub struct BaseWebParser {
+    name: String,
+    engine_type: SearchEngineType,
+}
+
+impl BaseWebParser {
+    pub fn new(name: String, engine_type: SearchEngineType) -> Self {
+        Self { name, engine_type }
+    }
+}
+
+impl BaseSearchParser for BaseWebParser {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn engine_type(&self) -> SearchEngineType {
+        self.engine_type.clone()
+    }
+}
+
+/// Base implementation for API parsers
+pub struct BaseApiParser {
+    name: String,
+    engine_type: SearchEngineType,
+}
+
+impl BaseApiParser {
+    pub fn new(name: String, engine_type: SearchEngineType) -> Self {
+        Self { name, engine_type }
+    }
+}
+
+impl BaseSearchParser for BaseApiParser {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn engine_type(&self) -> SearchEngineType {
+        self.engine_type.clone()
+    }
+}
+
+/// Helper functions for common parsing operations
+pub mod helpers {
+    use super::*;
+
+    /// Extract text from a JSON field safely
+    pub fn extract_json_text(json: &Value, field: &str) -> String {
+        json[field].as_str().unwrap_or("").to_string()
+    }
+
+    /// Extract text from a nested JSON field safely
+    pub fn extract_nested_json_text(json: &Value, path: &[&str]) -> String {
+        let mut current = json;
+        for field in path {
+            current = &current[field];
+        }
+        current.as_str().unwrap_or("").to_string()
+    }
+
+    /// Extract array from JSON safely
+    pub fn extract_json_array(json: &Value, field: &str) -> Option<Vec<Value>> {
+        json[field].as_array().cloned()
+    }
+
+    /// Extract nested array from JSON safely
+    pub fn extract_nested_json_array(json: &Value, path: &[&str]) -> Option<Vec<Value>> {
+        let mut current = json;
+        for field in path {
+            current = &current[field];
+        }
+        current.as_array().cloned()
+    }
+
+    /// Create a SearchResult from JSON fields
+    pub fn create_search_result_from_json(
+        json: &Value,
+        title_field: &str,
+        url_field: &str,
+        snippet_field: &str,
+        rank: usize,
+    ) -> SearchResult {
+        SearchResult {
+            title: extract_json_text(json, title_field),
+            url: extract_json_text(json, url_field),
+            snippet: extract_json_text(json, snippet_field),
+            rank,
+        }
+    }
+
+    /// Create a SearchResult from nested JSON fields
+    pub fn create_search_result_from_nested_json(
+        json: &Value,
+        title_path: &[&str],
+        url_path: &[&str],
+        snippet_path: &[&str],
+        rank: usize,
+    ) -> SearchResult {
+        SearchResult {
+            title: extract_nested_json_text(json, title_path),
+            url: extract_nested_json_text(json, url_path),
+            snippet: extract_nested_json_text(json, snippet_path),
+            rank,
+        }
+    }
+}

--- a/src/search/parser/duckduckgo.rs
+++ b/src/search/parser/duckduckgo.rs
@@ -1,35 +1,47 @@
+use super::super::types::{SearchEngineType, SearchResult};
 use super::SearchResultParser;
+use super::base::{
+    ApiSearchParser, BaseApiParser, BaseSearchParser, BaseWebParser, WebSearchParser, helpers,
+};
 use crate::Result;
-use crate::search::types::{SearchEngineType, SearchResult};
 use select::document::Document;
 use select::predicate::{Class, Name, Predicate};
-use tracing::{info, warn};
+use serde_json::Value;
 
-pub struct DuckDuckGoParser;
+/// DuckDuckGo web parser (HTML-based)
+pub struct DuckDuckGoParser {
+    base: BaseWebParser,
+}
 
 impl DuckDuckGoParser {
     pub fn new() -> Self {
-        Self
+        Self {
+            base: BaseWebParser::new("DuckDuckGoParser".to_string(), SearchEngineType::DuckDuckGo),
+        }
     }
 }
 
-impl SearchResultParser for DuckDuckGoParser {
-    fn parse(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        info!("Parsing DuckDuckGo search results from HTML");
+impl BaseSearchParser for DuckDuckGoParser {
+    fn name(&self) -> &str {
+        self.base.name()
+    }
 
-        if html.is_empty() {
-            warn!("Empty HTML provided to DuckDuckGoParser");
-            return Ok(Vec::new());
-        }
+    fn engine_type(&self) -> SearchEngineType {
+        self.base.engine_type()
+    }
+}
 
+impl WebSearchParser for DuckDuckGoParser {
+    fn parse_html(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
         let document = Document::from(html);
         let mut results = Vec::new();
 
-        // Look for DuckDuckGo search result containers
-        // DuckDuckGo uses .result__body for individual result containers
-        for (rank, node) in document.find(Class("result__body")).take(limit).enumerate() {
+        // DuckDuckGo search results are typically in elements with class "result__body"
+        for (i, result_element) in document.find(Class("result__body")).take(limit).enumerate() {
             // Extract title and URL from a.result__a element
-            let title_link = node.find(Name("a").and(Class("result__a"))).next();
+            let title_link = result_element
+                .find(Name("a").and(Class("result__a")))
+                .next();
 
             let title = title_link
                 .map(|n| n.text().trim().to_string())
@@ -50,7 +62,7 @@ impl SearchResultParser for DuckDuckGoParser {
                 .unwrap_or_default();
 
             // Extract snippet from .result__snippet element
-            let snippet = node
+            let snippet = result_element
                 .find(Class("result__snippet"))
                 .next()
                 .map(|n| n.text().trim().to_string())
@@ -58,38 +70,119 @@ impl SearchResultParser for DuckDuckGoParser {
 
             // Only add if we have at least a title
             if !title.is_empty() {
-                let result = SearchResult {
+                results.push(SearchResult {
                     title,
                     url,
                     snippet,
-                    rank: rank + 1,
-                };
-                info!(
-                    "Extracted DuckDuckGo result #{}: {}",
-                    rank + 1,
-                    result.title
-                );
-                results.push(result);
+                    rank: i + 1, // Test expects 1-based ranking
+                });
             }
         }
 
-        info!(
-            "Successfully parsed {} DuckDuckGo search results from HTML",
-            results.len()
-        );
         Ok(results)
+    }
+}
+
+impl SearchResultParser for DuckDuckGoParser {
+    fn parse(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        self.parse_html(html, limit)
     }
 
     fn name(&self) -> &str {
-        "DuckDuckGoParser"
+        BaseSearchParser::name(self)
     }
 
     fn supports(&self, engine_type: &SearchEngineType) -> bool {
-        matches!(engine_type, SearchEngineType::DuckDuckGo)
+        BaseSearchParser::supports(self, engine_type)
     }
 }
 
 impl Default for DuckDuckGoParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// DuckDuckGo API parser (JSON-based)
+pub struct DuckDuckGoApiParser {
+    base: BaseApiParser,
+}
+
+impl DuckDuckGoApiParser {
+    pub fn new() -> Self {
+        Self {
+            base: BaseApiParser::new(
+                "DuckDuckGoApiParser".to_string(),
+                SearchEngineType::DuckDuckGo,
+            ),
+        }
+    }
+}
+
+impl BaseSearchParser for DuckDuckGoApiParser {
+    fn name(&self) -> &str {
+        self.base.name()
+    }
+
+    fn engine_type(&self) -> SearchEngineType {
+        self.base.engine_type()
+    }
+}
+
+impl ApiSearchParser for DuckDuckGoApiParser {
+    fn parse_json(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        let json: Value = serde_json::from_str(json_content)?;
+        let mut results = Vec::new();
+
+        // Parse AbstractText if available
+        let abstract_text = helpers::extract_json_text(&json, "AbstractText");
+        if !abstract_text.is_empty() {
+            results.push(SearchResult {
+                title: helpers::extract_json_text(&json, "Heading"),
+                url: helpers::extract_json_text(&json, "AbstractURL"),
+                snippet: abstract_text,
+                rank: results.len(),
+            });
+        }
+
+        // Parse RelatedTopics if available
+        if let Some(related_topics) = helpers::extract_json_array(&json, "RelatedTopics") {
+            for topic in related_topics
+                .iter()
+                .take(limit.saturating_sub(results.len()))
+            {
+                let text = helpers::extract_json_text(topic, "Text");
+                let first_url = helpers::extract_json_text(topic, "FirstURL");
+                if !text.is_empty() && !first_url.is_empty() {
+                    results.push(SearchResult {
+                        title: text.split(" - ").next().unwrap_or("").to_string(),
+                        url: first_url,
+                        snippet: text,
+                        rank: results.len(),
+                    });
+                }
+            }
+        }
+
+        Ok(results.into_iter().take(limit).collect())
+    }
+}
+
+impl SearchResultParser for DuckDuckGoApiParser {
+    fn parse(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        self.parse_json(json_content, limit)
+    }
+
+    fn name(&self) -> &str {
+        BaseSearchParser::name(self)
+    }
+
+    fn supports(&self, engine_type: &SearchEngineType) -> bool {
+        BaseSearchParser::supports(self, engine_type)
+    }
+}
+
+impl Default for DuckDuckGoApiParser {
     fn default() -> Self {
         Self::new()
     }

--- a/src/search/parser/google.rs
+++ b/src/search/parser/google.rs
@@ -1,35 +1,47 @@
+use super::super::types::{SearchEngineType, SearchResult};
 use super::SearchResultParser;
+use super::base::{
+    ApiSearchParser, BaseApiParser, BaseSearchParser, BaseWebParser, WebSearchParser, helpers,
+};
 use crate::Result;
-use crate::search::types::{SearchEngineType, SearchResult};
 use select::document::Document;
 use select::predicate::{Class, Name, Predicate};
-use tracing::{info, warn};
+use serde_json::Value;
 
-pub struct GoogleParser;
+/// Google web parser (HTML-based)
+pub struct GoogleParser {
+    base: BaseWebParser,
+}
 
 impl GoogleParser {
     pub fn new() -> Self {
-        Self
+        Self {
+            base: BaseWebParser::new("GoogleParser".to_string(), SearchEngineType::Google),
+        }
     }
 }
 
-impl SearchResultParser for GoogleParser {
-    fn parse(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        info!("Parsing Google search results from HTML");
+impl BaseSearchParser for GoogleParser {
+    fn name(&self) -> &str {
+        self.base.name()
+    }
 
-        if html.is_empty() {
-            warn!("Empty HTML provided to GoogleParser");
-            return Ok(Vec::new());
-        }
+    fn engine_type(&self) -> SearchEngineType {
+        self.base.engine_type()
+    }
+}
 
+impl WebSearchParser for GoogleParser {
+    fn parse_html(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
         let document = Document::from(html);
         let mut results = Vec::new();
 
-        // Look for Google search result containers
-        // Google uses .tF2Cxc for individual result containers
-        for (rank, node) in document.find(Class("tF2Cxc")).take(limit).enumerate() {
+        // Google search results are typically in elements with class "tF2Cxc"
+        for (i, result_element) in document.find(Class("tF2Cxc")).take(limit).enumerate() {
             // Extract title and URL from .yuRUbf a element
-            let title_link = node.find(Class("yuRUbf").descendant(Name("a"))).next();
+            let title_link = result_element
+                .find(Class("yuRUbf").descendant(Name("a")))
+                .next();
 
             let title = title_link
                 .map(|n| n.text().trim().to_string())
@@ -50,7 +62,7 @@ impl SearchResultParser for GoogleParser {
                 .unwrap_or_default();
 
             // Extract snippet from .IsZvec element
-            let snippet = node
+            let snippet = result_element
                 .find(Class("IsZvec"))
                 .next()
                 .map(|n| n.text().trim().to_string())
@@ -58,34 +70,157 @@ impl SearchResultParser for GoogleParser {
 
             // Only add if we have at least a title
             if !title.is_empty() {
-                let result = SearchResult {
+                results.push(SearchResult {
                     title,
                     url,
                     snippet,
-                    rank: rank + 1,
-                };
-                info!("Extracted Google result #{}: {}", rank + 1, result.title);
-                results.push(result);
+                    rank: i + 1, // Test expects 1-based ranking
+                });
             }
         }
 
-        info!(
-            "Successfully parsed {} Google search results from HTML",
-            results.len()
-        );
         Ok(results)
+    }
+}
+
+impl SearchResultParser for GoogleParser {
+    fn parse(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        self.parse_html(html, limit)
     }
 
     fn name(&self) -> &str {
-        "GoogleParser"
+        BaseSearchParser::name(self)
     }
 
     fn supports(&self, engine_type: &SearchEngineType) -> bool {
-        matches!(engine_type, SearchEngineType::Google)
+        BaseSearchParser::supports(self, engine_type)
     }
 }
 
 impl Default for GoogleParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Google API parser (JSON-based)
+pub struct GoogleApiParser {
+    base: BaseApiParser,
+}
+
+impl GoogleApiParser {
+    pub fn new() -> Self {
+        Self {
+            base: BaseApiParser::new("GoogleApiParser".to_string(), SearchEngineType::Google),
+        }
+    }
+}
+
+impl BaseSearchParser for GoogleApiParser {
+    fn name(&self) -> &str {
+        self.base.name()
+    }
+
+    fn engine_type(&self) -> SearchEngineType {
+        self.base.engine_type()
+    }
+}
+
+impl ApiSearchParser for GoogleApiParser {
+    fn parse_json(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        let json: Value = serde_json::from_str(json_content)?;
+        let mut results = Vec::new();
+
+        if let Some(organic_results) = helpers::extract_json_array(&json, "organic") {
+            for (i, result) in organic_results.iter().take(limit).enumerate() {
+                results.push(helpers::create_search_result_from_json(
+                    result, "title", "link", "snippet", i,
+                ));
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+impl SearchResultParser for GoogleApiParser {
+    fn parse(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        self.parse_json(json_content, limit)
+    }
+
+    fn name(&self) -> &str {
+        BaseSearchParser::name(self)
+    }
+
+    fn supports(&self, engine_type: &SearchEngineType) -> bool {
+        BaseSearchParser::supports(self, engine_type)
+    }
+}
+
+impl Default for GoogleApiParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Google Serper API parser (JSON-based)
+pub struct GoogleSerperApiParser {
+    base: BaseApiParser,
+}
+
+impl GoogleSerperApiParser {
+    pub fn new() -> Self {
+        Self {
+            base: BaseApiParser::new(
+                "GoogleSerperApiParser".to_string(),
+                SearchEngineType::GoogleSerper,
+            ),
+        }
+    }
+}
+
+impl BaseSearchParser for GoogleSerperApiParser {
+    fn name(&self) -> &str {
+        self.base.name()
+    }
+
+    fn engine_type(&self) -> SearchEngineType {
+        self.base.engine_type()
+    }
+}
+
+impl ApiSearchParser for GoogleSerperApiParser {
+    fn parse_json(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        let json: Value = serde_json::from_str(json_content)?;
+        let mut results = Vec::new();
+
+        if let Some(organic_results) = helpers::extract_json_array(&json, "organic") {
+            for (i, result) in organic_results.iter().take(limit).enumerate() {
+                results.push(helpers::create_search_result_from_json(
+                    result, "title", "link", "snippet", i,
+                ));
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+impl SearchResultParser for GoogleSerperApiParser {
+    fn parse(&self, json_content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        self.parse_json(json_content, limit)
+    }
+
+    fn name(&self) -> &str {
+        BaseSearchParser::name(self)
+    }
+
+    fn supports(&self, engine_type: &SearchEngineType) -> bool {
+        BaseSearchParser::supports(self, engine_type)
+    }
+}
+
+impl Default for GoogleSerperApiParser {
     fn default() -> Self {
         Self::new()
     }

--- a/src/search/parser/mod.rs
+++ b/src/search/parser/mod.rs
@@ -1,7 +1,8 @@
-use super::types::{SearchEngineType, SearchResult};
+use super::types::{SearchEngineType, SearchMode, SearchResult};
 use crate::Result;
 
 pub mod baidu;
+pub mod base;
 pub mod bing;
 pub mod brave;
 pub mod custom;
@@ -11,14 +12,109 @@ pub mod google;
 #[cfg(test)]
 mod tests;
 
-pub use baidu::BaiduParser;
+pub use baidu::{BaiduApiParser, BaiduParser};
 pub use bing::BingParser;
-pub use brave::BraveParser;
-pub use custom::{CustomParser, CustomParserConfig};
-pub use duckduckgo::DuckDuckGoParser;
-pub use google::GoogleParser;
+pub use brave::{BraveApiParser, BraveParser};
+pub use custom::{CustomParser, CustomParserConfig, ExaApiParser, TravilyApiParser};
+pub use duckduckgo::{DuckDuckGoApiParser, DuckDuckGoParser};
+pub use google::{GoogleApiParser, GoogleParser, GoogleSerperApiParser};
 
-/// Trait for parsing search results from HTML content
+use base::{ApiSearchParser, BaseSearchParser, WebSearchParser};
+
+/// Unified parser that can handle both web and API queries
+pub struct UnifiedParser {
+    web_parser: Box<dyn WebSearchParser>,
+    api_parser: Option<Box<dyn ApiSearchParser>>,
+}
+
+impl UnifiedParser {
+    pub fn new(
+        web_parser: Box<dyn WebSearchParser>,
+        api_parser: Option<Box<dyn ApiSearchParser>>,
+    ) -> Self {
+        Self {
+            web_parser,
+            api_parser,
+        }
+    }
+
+    pub fn web_only(web_parser: Box<dyn WebSearchParser>) -> Self {
+        Self {
+            web_parser,
+            api_parser: None,
+        }
+    }
+
+    pub fn api_only(api_parser: Box<dyn ApiSearchParser>) -> Self {
+        Self {
+            web_parser: Box::new(DummyWebParser::new()),
+            api_parser: Some(api_parser),
+        }
+    }
+}
+
+impl SearchResultParser for UnifiedParser {
+    fn parse(&self, content: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        // Try to detect if content is JSON or HTML
+        if content.trim().starts_with('{') || content.trim().starts_with('[') {
+            // Likely JSON content
+            if let Some(ref api_parser) = self.api_parser {
+                api_parser.parse_json(content, limit)
+            } else {
+                // Fallback to web parser if no API parser available
+                self.web_parser.parse_html(content, limit)
+            }
+        } else {
+            // Likely HTML content
+            self.web_parser.parse_html(content, limit)
+        }
+    }
+
+    fn name(&self) -> &str {
+        self.web_parser.name()
+    }
+
+    fn supports(&self, engine_type: &SearchEngineType) -> bool {
+        self.web_parser.supports(engine_type)
+            || self
+                .api_parser
+                .as_ref()
+                .is_some_and(|p| p.supports(engine_type))
+    }
+}
+
+/// Dummy web parser for API-only engines
+struct DummyWebParser {
+    name: String,
+    engine_type: SearchEngineType,
+}
+
+impl DummyWebParser {
+    fn new() -> Self {
+        Self {
+            name: "DummyWebParser".to_string(),
+            engine_type: SearchEngineType::Custom("dummy".to_string()),
+        }
+    }
+}
+
+impl BaseSearchParser for DummyWebParser {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn engine_type(&self) -> SearchEngineType {
+        self.engine_type.clone()
+    }
+}
+
+impl WebSearchParser for DummyWebParser {
+    fn parse_html(&self, _html: &str, _limit: usize) -> Result<Vec<SearchResult>> {
+        Ok(Vec::new()) // Return empty results for API-only engines
+    }
+}
+
+/// Trait for parsing search results from HTML content (legacy compatibility)
 pub trait SearchResultParser: Send + Sync {
     /// Parse search results from HTML content
     fn parse(&self, html: &str, limit: usize) -> Result<Vec<SearchResult>>;
@@ -47,29 +143,70 @@ impl ParserFactory {
         self.custom_parsers.insert(name, parser);
     }
 
-    /// Get a parser for the given search engine type
-    pub fn get_parser(&self, engine_type: &SearchEngineType) -> Box<dyn SearchResultParser> {
-        match engine_type {
-            SearchEngineType::Bing => Box::new(BingParser::new()),
-            SearchEngineType::DuckDuckGo => Box::new(DuckDuckGoParser::new()),
-            SearchEngineType::Google => Box::new(GoogleParser::new()),
-            SearchEngineType::BraveSearch => Box::new(BraveParser::new()),
-            SearchEngineType::Baidu => Box::new(BaiduParser::new()),
-            SearchEngineType::Exa => Box::new(CustomParser::new("Exa".to_string())),
-            SearchEngineType::Travily => Box::new(CustomParser::new("Travily".to_string())),
-            SearchEngineType::GoogleSerper => {
-                Box::new(CustomParser::new("GoogleSerper".to_string()))
+    /// Get a parser for the given search engine type and mode
+    pub fn get_parser(
+        &self,
+        engine_type: &SearchEngineType,
+        mode: SearchMode,
+    ) -> Box<dyn SearchResultParser> {
+        match (engine_type, mode) {
+            // Web query parsers (HTML-based)
+            (SearchEngineType::Bing, SearchMode::WebQuery) => Box::new(BingParser::new()),
+            (SearchEngineType::DuckDuckGo, SearchMode::WebQuery) => {
+                Box::new(DuckDuckGoParser::new())
             }
-            SearchEngineType::Custom(name) => {
+            (SearchEngineType::Google, SearchMode::WebQuery) => Box::new(GoogleParser::new()),
+            (SearchEngineType::BraveSearch, SearchMode::WebQuery) => Box::new(BraveParser::new()),
+            (SearchEngineType::Baidu, SearchMode::WebQuery) => Box::new(BaiduParser::new()),
+
+            // API query parsers (JSON-based)
+            (SearchEngineType::DuckDuckGo, SearchMode::ApiQuery) => {
+                Box::new(DuckDuckGoApiParser::new())
+            }
+            (SearchEngineType::Google, SearchMode::ApiQuery) => Box::new(GoogleApiParser::new()),
+            (SearchEngineType::BraveSearch, SearchMode::ApiQuery) => {
+                Box::new(BraveApiParser::new())
+            }
+            (SearchEngineType::Baidu, SearchMode::ApiQuery) => Box::new(BaiduApiParser::new()),
+            (SearchEngineType::Exa, SearchMode::ApiQuery) => Box::new(ExaApiParser::new()),
+            (SearchEngineType::Travily, SearchMode::ApiQuery) => Box::new(TravilyApiParser::new()),
+            (SearchEngineType::GoogleSerper, SearchMode::ApiQuery) => {
+                Box::new(GoogleSerperApiParser::new())
+            }
+
+            // Fallback for unsupported combinations
+            (SearchEngineType::Bing, SearchMode::ApiQuery) => {
+                // Bing doesn't support API queries, but we'll provide a fallback parser
+                Box::new(CustomParser::new("BingApiFallback".to_string()))
+            }
+            (SearchEngineType::Exa, SearchMode::WebQuery) => {
+                // Exa is API-only, but we'll provide a fallback parser
+                Box::new(CustomParser::new("ExaWebFallback".to_string()))
+            }
+            (SearchEngineType::Travily, SearchMode::WebQuery) => {
+                // Travily is API-only, but we'll provide a fallback parser
+                Box::new(CustomParser::new("TravilyWebFallback".to_string()))
+            }
+            (SearchEngineType::GoogleSerper, SearchMode::WebQuery) => {
+                // GoogleSerper is API-only, but we'll provide a fallback parser
+                Box::new(CustomParser::new("GoogleSerperWebFallback".to_string()))
+            }
+
+            // Custom engine parsers
+            (SearchEngineType::Custom(name), _) => {
                 if let Some(_parser) = self.custom_parsers.get(name) {
-                    // Note: This is a simplified approach. In practice, you might want
-                    // to use Arc<dyn SearchResultParser> for shared ownership
                     Box::new(CustomParser::new(name.clone()))
                 } else {
                     Box::new(CustomParser::new(name.clone()))
                 }
             }
         }
+    }
+
+    /// Get a parser for the given search engine type (legacy method for backward compatibility)
+    pub fn get_parser_legacy(&self, engine_type: &SearchEngineType) -> Box<dyn SearchResultParser> {
+        // Default to web query mode for backward compatibility
+        self.get_parser(engine_type, SearchMode::WebQuery)
     }
 }
 

--- a/src/search/parser/tests.rs
+++ b/src/search/parser/tests.rs
@@ -1,5 +1,8 @@
-use super::*;
-use crate::search::types::SearchEngineType;
+use super::super::types::{SearchEngineType, SearchMode};
+use super::{
+    BaiduParser, BingParser, BraveParser, CustomParser, CustomParserConfig, DuckDuckGoParser,
+    GoogleParser, ParserFactory, SearchResultParser,
+};
 
 #[test]
 fn test_bing_parser() {
@@ -250,24 +253,42 @@ fn test_custom_parser_with_config() {
 fn test_parser_factory() {
     let factory = ParserFactory::new();
 
-    // Test all built-in parsers
-    let bing_parser = factory.get_parser(&SearchEngineType::Bing);
+    // Test web query parsers
+    let bing_parser = factory.get_parser(&SearchEngineType::Bing, SearchMode::WebQuery);
+    let google_parser = factory.get_parser(&SearchEngineType::Google, SearchMode::WebQuery);
+    let duckduckgo_parser = factory.get_parser(&SearchEngineType::DuckDuckGo, SearchMode::WebQuery);
+    let brave_parser = factory.get_parser(&SearchEngineType::BraveSearch, SearchMode::WebQuery);
+    let baidu_parser = factory.get_parser(&SearchEngineType::Baidu, SearchMode::WebQuery);
+    let custom_parser = factory.get_parser(
+        &SearchEngineType::Custom("TestCustom".to_string()),
+        SearchMode::WebQuery,
+    );
+
     assert_eq!(bing_parser.name(), "BingParser");
-
-    let google_parser = factory.get_parser(&SearchEngineType::Google);
     assert_eq!(google_parser.name(), "GoogleParser");
-
-    let duckduckgo_parser = factory.get_parser(&SearchEngineType::DuckDuckGo);
     assert_eq!(duckduckgo_parser.name(), "DuckDuckGoParser");
-
-    let brave_parser = factory.get_parser(&SearchEngineType::BraveSearch);
     assert_eq!(brave_parser.name(), "BraveParser");
-
-    let baidu_parser = factory.get_parser(&SearchEngineType::Baidu);
     assert_eq!(baidu_parser.name(), "BaiduParser");
-
-    let custom_parser = factory.get_parser(&SearchEngineType::Custom("TestCustom".to_string()));
     assert_eq!(custom_parser.name(), "TestCustom");
+
+    // Test API query parsers
+    let duckduckgo_api_parser =
+        factory.get_parser(&SearchEngineType::DuckDuckGo, SearchMode::ApiQuery);
+    let google_api_parser = factory.get_parser(&SearchEngineType::Google, SearchMode::ApiQuery);
+    let brave_api_parser = factory.get_parser(&SearchEngineType::BraveSearch, SearchMode::ApiQuery);
+    let baidu_api_parser = factory.get_parser(&SearchEngineType::Baidu, SearchMode::ApiQuery);
+    let exa_api_parser = factory.get_parser(&SearchEngineType::Exa, SearchMode::ApiQuery);
+    let travily_api_parser = factory.get_parser(&SearchEngineType::Travily, SearchMode::ApiQuery);
+    let google_serper_api_parser =
+        factory.get_parser(&SearchEngineType::GoogleSerper, SearchMode::ApiQuery);
+
+    assert_eq!(duckduckgo_api_parser.name(), "DuckDuckGoApiParser");
+    assert_eq!(google_api_parser.name(), "GoogleApiParser");
+    assert_eq!(brave_api_parser.name(), "BraveApiParser");
+    assert_eq!(baidu_api_parser.name(), "BaiduApiParser");
+    assert_eq!(exa_api_parser.name(), "ExaApiParser");
+    assert_eq!(travily_api_parser.name(), "TravilyApiParser");
+    assert_eq!(google_serper_api_parser.name(), "GoogleSerperApiParser");
 }
 
 #[test]
@@ -279,7 +300,10 @@ fn test_parser_factory_with_custom_parser() {
     factory.register_custom_parser("MyCustomEngine".to_string(), custom_parser);
 
     // Test that we can get the custom parser
-    let parser = factory.get_parser(&SearchEngineType::Custom("MyCustomEngine".to_string()));
+    let parser = factory.get_parser(
+        &SearchEngineType::Custom("MyCustomEngine".to_string()),
+        SearchMode::WebQuery,
+    );
     assert_eq!(parser.name(), "MyCustomEngine");
 }
 
@@ -297,7 +321,7 @@ fn test_all_parsers_with_different_limits() {
     ];
 
     for (engine_type, expected_name) in test_cases {
-        let parser = factory.get_parser(&engine_type);
+        let parser = factory.get_parser(&engine_type, SearchMode::WebQuery);
         assert_eq!(parser.name(), expected_name);
 
         // Test with different limits

--- a/src/search/tests.rs
+++ b/src/search/tests.rs
@@ -9,11 +9,8 @@ fn test_searchengine_from_config() {
     let engine = SearchEngine::from_config(&config);
     // Note: The general api_key is deprecated, specific API keys are managed per provider
     assert_eq!(*engine.api_key(), None);
-    assert_eq!(*engine.engine_type(), SearchEngineType::Bing);
-    assert_eq!(
-        engine.query_pattern(),
-        "https://www.bing.com/search?q={query}"
-    );
+    assert_eq!(*engine.engine_type(), SearchEngineType::DuckDuckGo);
+    assert_eq!(engine.query_pattern(), "https://duckduckgo.com/?q={query}");
     assert_eq!(engine.user_agent(), crate::constants::DEFAULT_USER_AGENT);
 }
 
@@ -99,11 +96,8 @@ fn test_custom_user_agent() {
 fn test_searchengine_new() {
     let engine = SearchEngine::new();
     assert_eq!(*engine.api_key(), None);
-    assert_eq!(*engine.engine_type(), SearchEngineType::Bing);
-    assert_eq!(
-        engine.query_pattern(),
-        "https://www.bing.com/search?q={query}"
-    );
+    assert_eq!(*engine.engine_type(), SearchEngineType::DuckDuckGo);
+    assert_eq!(engine.query_pattern(), "https://duckduckgo.com/?q={query}");
     assert_eq!(engine.user_agent(), crate::constants::DEFAULT_USER_AGENT);
 }
 
@@ -175,8 +169,195 @@ fn test_search_mode_clone() {
 }
 
 #[test]
+fn test_engine_capabilities() {
+    // Test DuckDuckGo capabilities
+    assert!(SearchEngineType::DuckDuckGo.supports_web_query());
+    assert!(SearchEngineType::DuckDuckGo.supports_api_query());
+    assert!(!SearchEngineType::DuckDuckGo.requires_api_key());
+
+    // Test Google capabilities
+    assert!(SearchEngineType::Google.supports_web_query());
+    assert!(SearchEngineType::Google.supports_api_query());
+    assert!(SearchEngineType::Google.requires_api_key());
+
+    // Test Bing capabilities
+    assert!(SearchEngineType::Bing.supports_web_query());
+    assert!(!SearchEngineType::Bing.supports_api_query()); // Bing doesn't have public API
+    assert!(!SearchEngineType::Bing.requires_api_key());
+
+    // Test Brave capabilities
+    assert!(SearchEngineType::BraveSearch.supports_web_query());
+    assert!(SearchEngineType::BraveSearch.supports_api_query());
+    assert!(SearchEngineType::BraveSearch.requires_api_key());
+
+    // Test Baidu capabilities
+    assert!(SearchEngineType::Baidu.supports_web_query());
+    assert!(SearchEngineType::Baidu.supports_api_query());
+    assert!(SearchEngineType::Baidu.requires_api_key());
+
+    // Test API-only engines
+    assert!(SearchEngineType::Exa.supports_web_query());
+    assert!(SearchEngineType::Exa.supports_api_query());
+    assert!(SearchEngineType::Exa.requires_api_key());
+
+    assert!(!SearchEngineType::Travily.supports_web_query());
+    assert!(SearchEngineType::Travily.supports_api_query());
+    assert!(SearchEngineType::Travily.requires_api_key());
+
+    assert!(SearchEngineType::GoogleSerper.supports_web_query());
+    assert!(SearchEngineType::GoogleSerper.supports_api_query());
+    assert!(SearchEngineType::GoogleSerper.requires_api_key());
+}
+
+#[test]
+fn test_api_key_fields() {
+    assert_eq!(SearchEngineType::Bing.get_api_key_field(), None);
+    assert_eq!(SearchEngineType::DuckDuckGo.get_api_key_field(), None);
+    assert_eq!(
+        SearchEngineType::Google.get_api_key_field(),
+        Some("google_serper_api_key")
+    );
+    assert_eq!(
+        SearchEngineType::BraveSearch.get_api_key_field(),
+        Some("brave_api_key")
+    );
+    assert_eq!(
+        SearchEngineType::Baidu.get_api_key_field(),
+        Some("baidu_api_key")
+    );
+    assert_eq!(
+        SearchEngineType::Exa.get_api_key_field(),
+        Some("exa_api_key")
+    );
+    assert_eq!(
+        SearchEngineType::Travily.get_api_key_field(),
+        Some("travily_api_key")
+    );
+    assert_eq!(
+        SearchEngineType::GoogleSerper.get_api_key_field(),
+        Some("google_serper_api_key")
+    );
+}
+
+#[test]
+fn test_engine_mode_validation() {
+    use crate::config::Config;
+
+    // Test that Bing doesn't support API query
+    let mut config = Config::new();
+    config.search.engine = "bing".to_string();
+    config.search.mode = "apiquery".to_string();
+
+    let engine = SearchEngine::from_config(&config);
+    // Test the validation logic directly
+    assert!(!engine.engine_type().supports_api_query());
+    assert!(engine.engine_type().supports_web_query());
+
+    // Test that Travily doesn't support web query
+    let mut config2 = Config::new();
+    config2.search.engine = "travily".to_string();
+    config2.search.mode = "webquery".to_string();
+
+    let engine2 = SearchEngine::from_config(&config2);
+    assert!(!engine2.engine_type().supports_web_query());
+    assert!(engine2.engine_type().supports_api_query());
+
+    // Test that Google supports both modes
+    let mut config3 = Config::new();
+    config3.search.engine = "google".to_string();
+    config3.search.mode = "webquery".to_string();
+
+    let engine3 = SearchEngine::from_config(&config3);
+    assert!(engine3.engine_type().supports_web_query());
+    assert!(engine3.engine_type().supports_api_query());
+}
+
+#[test]
 fn test_search_mode_copy() {
     let mode1 = SearchMode::WebQuery;
     let mode2 = mode1; // This should work because SearchMode is Copy
     assert_eq!(mode1, mode2);
+}
+
+#[test]
+fn test_query_patterns_for_modes() {
+    use crate::search::SearchMode;
+
+    // Test DuckDuckGo patterns
+    assert_eq!(
+        SearchEngineType::DuckDuckGo.get_query_pattern_for_mode(SearchMode::WebQuery),
+        "https://duckduckgo.com/?q={query}"
+    );
+    assert_eq!(
+        SearchEngineType::DuckDuckGo.get_query_pattern_for_mode(SearchMode::ApiQuery),
+        "https://api.duckduckgo.com/?q={query}&format=json"
+    );
+
+    // Test Google patterns
+    assert_eq!(
+        SearchEngineType::Google.get_query_pattern_for_mode(SearchMode::WebQuery),
+        "https://www.google.com/search?q={query}"
+    );
+    assert_eq!(
+        SearchEngineType::Google.get_query_pattern_for_mode(SearchMode::ApiQuery),
+        "https://google.serper.dev/search"
+    );
+
+    // Test Bing patterns
+    assert_eq!(
+        SearchEngineType::Bing.get_query_pattern_for_mode(SearchMode::WebQuery),
+        "https://www.bing.com/search?q={query}"
+    );
+    assert_eq!(
+        SearchEngineType::Bing.get_query_pattern_for_mode(SearchMode::ApiQuery),
+        ""
+    );
+
+    // Test Brave patterns
+    assert_eq!(
+        SearchEngineType::BraveSearch.get_query_pattern_for_mode(SearchMode::WebQuery),
+        "https://search.brave.com/search?q={query}"
+    );
+    assert_eq!(
+        SearchEngineType::BraveSearch.get_query_pattern_for_mode(SearchMode::ApiQuery),
+        "https://api.search.brave.com/res/v1/web/search"
+    );
+
+    // Test Baidu patterns
+    assert_eq!(
+        SearchEngineType::Baidu.get_query_pattern_for_mode(SearchMode::WebQuery),
+        "https://www.baidu.com/s?wd={query}"
+    );
+    assert_eq!(
+        SearchEngineType::Baidu.get_query_pattern_for_mode(SearchMode::ApiQuery),
+        "https://api.baidu.com/search"
+    );
+
+    // Test API-only engines
+    assert_eq!(
+        SearchEngineType::Exa.get_query_pattern_for_mode(SearchMode::WebQuery),
+        "https://exa.ai/search?q={query}"
+    );
+    assert_eq!(
+        SearchEngineType::Exa.get_query_pattern_for_mode(SearchMode::ApiQuery),
+        "https://api.exa.ai/search"
+    );
+
+    assert_eq!(
+        SearchEngineType::Travily.get_query_pattern_for_mode(SearchMode::WebQuery),
+        ""
+    );
+    assert_eq!(
+        SearchEngineType::Travily.get_query_pattern_for_mode(SearchMode::ApiQuery),
+        "https://api.tavily.com/search"
+    );
+
+    assert_eq!(
+        SearchEngineType::GoogleSerper.get_query_pattern_for_mode(SearchMode::WebQuery),
+        "https://www.google.com/search?q={query}"
+    );
+    assert_eq!(
+        SearchEngineType::GoogleSerper.get_query_pattern_for_mode(SearchMode::ApiQuery),
+        "https://google.serper.dev/search"
+    );
 }

--- a/tarzi.toml
+++ b/tarzi.toml
@@ -20,7 +20,7 @@
 # -----------------------------------------------------------------------------
 [fetcher]
 # Fetcher mode - how to retrieve web content
-# Options: "browser_headless", "browser_headed", "http"
+# Options: "browser_headless", "browser_headed", "plain_request"
 # mode = "browser_headless"
 
 # Output format for fetched content
@@ -48,7 +48,7 @@
 
 # Search engine to use
 # Options: "google", "bing", "duckduckgo", "brave", "baidu", "exa", "travily", "google_serper"
-# engine = "bing"
+# engine = "duckduckgo"
 
 # URL pattern for search queries when engine is "custom"
 # Use {query} as placeholder for the search term
@@ -61,20 +61,9 @@
 # Options: "smart" (automatically switch using internal policies), "none" (only use search.engine)
 # autoswitch = "smart"
 
-# API keys for different search engines
-# Required when using apiquery mode with specific search engines
-
-# Brave Search API key
+# API keys for supported providers
 # brave_api_key = "your-brave-api-key"
-
-# DuckDuckGo API key
-# duckduckgo_api_key = "your-duckduckgo-api-key"
-
-# Google Serper API key
 # google_serper_api_key = "your-google-serper-api-key"
-
-# Exa Search API key
 # exa_api_key = "your-exa-api-key"
-
-# Travily API key
 # travily_api_key = "your-travily-api-key"
+# baidu_api_key = "your-baidu-api-key"


### PR DESCRIPTION
- Add BaseSearchParser, WebSearchParser, ApiSearchParser traits
- Refactor all engine parsers to inherit from base classes
- Add ParserFactory for mode-aware parser selection
- Update documentation to reflect new architecture
- Improve search engine configuration and CLI handling
- Add Baidu search engine support
- Remove duckduckgo_api_key requirement
- Set DuckDuckGo as default engine for both web and API queries
- Enforce fetcher mode constraints based on search mode
- Add comprehensive tests for new parser structure

All parsers now follow consistent patterns with reduced boilerplate and improved maintainability for future engine additions.