### PR TITLE
Polish mcp server arguments

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -136,7 +136,7 @@ Fetch content from a web URL with optional browser automation.
 **Parameters:**
 - `url` (string): URL to fetch
 - `format` (string, default: "html"): Output format ("html", "markdown", "json", "yaml")
-- `mode` (string, default: "plain_request"): Fetch mode ("plain_request" or "browser")
+- `mode` (string, default: "plain_request"): Fetch mode ("plain_request", "browser_headless", or "browser_headed")
 
 **Returns:** Fetched content in the specified format.
 
@@ -145,13 +145,15 @@ Fetch content from a web URL with optional browser automation.
 - Dynamic content rendering
 - Anti-bot detection bypass
 - Automatic configuration
+- `browser_headless`: Faster execution without GUI
+- `browser_headed`: Visible browser window for debugging
 
 **Example:**
 ```json
 {
   "url": "https://example.com",
   "format": "markdown",
-  "mode": "browser"
+  "mode": "browser_headless"
 }
 ```
 
@@ -180,8 +182,8 @@ Search and fetch content from results with browser automation support.
 **Parameters:**
 - `query` (string): Search query
 - `limit` (integer, default: 5): Maximum results to process
-- `search_mode` (string, default: "webquery"): Search mode
-- `fetch_mode` (string, default: "plain_request"): Fetch mode ("plain_request" or "browser")
+- `search_mode` (string, default: "webquery"): Search mode ("webquery" or "apiquery")
+- `fetch_mode` (string, default: "plain_request"): Fetch mode ("plain_request", "browser_headless", or "browser_headed")
 - `content_format` (string, default: "markdown"): Content format
 
 **Returns:** Search results with fetched content.
@@ -290,7 +292,7 @@ docker build -t tarzi-mcp-server .
    ```
 
 2. **JavaScript not executing**:
-   - Ensure you're using `mode: "browser"` in fetch_url
+   - Ensure you're using `mode: "browser_headless"` or `mode: "browser_headed"` in fetch_url
    - Browser configuration is handled automatically by tarzi
 
 3. **Memory issues**:

--- a/mcp/tarzi_mcp_server/server.py
+++ b/mcp/tarzi_mcp_server/server.py
@@ -100,7 +100,7 @@ def fetch_url(
     Args:
         url: URL to fetch
         format: Output format - 'html', 'markdown', 'json', or 'yaml'
-        mode: Fetch mode - 'plain_request' for simple HTTP, 'browser' for browser automation
+        mode: Fetch mode - 'plain_request' for simple HTTP, 'browser_headless' for headless browser, 'browser_headed' for browser with head
         
     Returns:
         Fetched content in the specified format
@@ -111,10 +111,10 @@ def fetch_url(
             raise ValueError("Format must be 'html', 'markdown', 'json', or 'yaml'")
             
         # Validate mode
-        if mode not in ["plain_request", "browser"]:
-            raise ValueError("Mode must be 'plain_request' or 'browser'")
+        if mode not in ["plain_request", "browser_headless", "browser_headed"]:
+            raise ValueError("Mode must be 'plain_request', 'browser_headless', or 'browser_headed'")
             
-        # Fetch content using tarzi (tarzi handles browser automation dynamically)
+        # Fetch content using tarzi
         content = tarzi.fetch_url(url, mode, format)
         
         logger.info(f"URL fetched successfully: {url} in {format} format using {mode} mode")
@@ -167,8 +167,8 @@ def search_and_fetch(
     Args:
         query: Search query string
         limit: Maximum number of results to process (default: 5)
-        search_mode: Search mode - 'webquery' or 'apiquery'
-        fetch_mode: Fetch mode - 'plain_request' or 'browser'
+        search_mode: Search mode - 'webquery' for browser-based search, 'apiquery' for API-based search
+        fetch_mode: Fetch mode - 'plain_request' for simple HTTP, 'browser_headless' for headless browser, 'browser_headed' for browser with head
         content_format: Content format - 'html', 'markdown', 'json', or 'yaml'
         
     Returns:
@@ -178,12 +178,12 @@ def search_and_fetch(
         # Validate parameters
         if search_mode not in ["webquery", "apiquery"]:
             raise ValueError("Search mode must be 'webquery' or 'apiquery'")
-        if fetch_mode not in ["plain_request", "browser"]:
-            raise ValueError("Fetch mode must be 'plain_request' or 'browser'")
+        if fetch_mode not in ["plain_request", "browser_headless", "browser_headed"]:
+            raise ValueError("Fetch mode must be 'plain_request', 'browser_headless', or 'browser_headed'")
         if content_format not in ["html", "markdown", "json", "yaml"]:
             raise ValueError("Content format must be 'html', 'markdown', 'json', or 'yaml'")
             
-        # Perform search and fetch using tarzi (tarzi handles browser automation dynamically)
+        # Perform search and fetch using tarzi
         results_with_content = tarzi.search_and_fetch(
             query, search_mode, limit, fetch_mode, content_format
         )
@@ -223,7 +223,7 @@ def get_config() -> str:
 - Default timeout: 30s
 - Default user agent: Tarzi Search Client
 - Available search modes: webquery, apiquery
-- Available fetch modes: plain_request, browser
+- Available fetch modes: plain_request, browser_headless, browser_headed
 - Supported formats: html, markdown, json, yaml
 """
     except Exception as e:


### PR DESCRIPTION
Align MCP server `fetch_mode` arguments and documentation with the `tarzi` library API to support `browser_headless` and `browser_headed`.